### PR TITLE
Adds quick links to assigned issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,22 +12,22 @@ For planning meeting notes and information, please visit the [Planning Doc](http
 Find an overview of the EEW investigation outcomes, spreadsheets of Jupyter Notebook and Primers on this [tracking spreadsheet](https://docs.google.com/document/d/1ZraEefQMhF1XWDrZi8Igr9gQUWD2n2LM5n26CLmxbB8/edit#heading=h.s8auecfa33q0).
 
 ## People of EEW
-| Name | Github | Role/Area of responsibility/Tag me on conversations about... |
-| ------|--------|----------------------|
-| Sara Wylie | @saraannwylie | EEW event co-coordinator, budget and hiring coordinator, fundraising and partnership outreach co-coordinator |
-| Lourdes Vera | @lourdesvera |EEW event co-coordinator, intern management, Gihub project management, data visualization and story gathering tracks, website management and review|
-| Kelly Wilkinson | @EDGI-Comms|*enter text here*  |
-| Cole Alder | @calderEDJ |EEW website maintenance; event support; participant offboarding, visualization / outcome development and management; media coverage tracking  |
-| Casey Greenleaf | @crgreenleaf |EEW event support, participant onboarding, partnership and outreach co-coordinator, general questions   | 
-| Steve Hansen | @shansen5 | Programming and database support; Jupyter Notebook development; Mentoring on programming and development; Event notebook demonstrations|
-| Chris Sellers | @csellers9 | Moderating Database/Notebook-writing group; Liaison to SBU faculty, also to EPA ECHO staff |
-| Eric Nost | @ericnost  | Github use & management, general questions, code reviews for Jupyter notebooks, data visualization and research/contextualization tracks |
-| Kelsey Breseman | @Frijol | Github use & management, general questions, interfacing with EDGI, code reviews for Jupyter notebooks |
-| Sung-Gheel Jang | @sunggheel |*enter text here* |
-| Paul St. Denis | @pstdenis |*enter text here*  |
-| Dan Pascucci | @danpascucci |*enter text here*  |
-| Dietmar Offenhuber | @dietoff |Data visualization track, UX research, EEW in the classroom|
-| Gaby Trudo| @gabrielletrudo | Communications and social media intern|
+| Name | Github | Role/Area of responsibility/Tag me on conversations about... | Assigned issues |
+| ------|--------|----------------------|-|
+| Sara Wylie | @saraannwylie | EEW event co-coordinator, budget and hiring coordinator, fundraising and partnership outreach co-coordinator | https://github.com/edgi-govdata-archiving/EEW_Planning/issues/assigned/saraannwylie |
+| Lourdes Vera | @lourdesvera |EEW event co-coordinator, intern management, Gihub project management, data visualization and story gathering tracks, website management and review| https://github.com/edgi-govdata-archiving/EEW_Planning/issues/assigned/lourdesvera |
+| Kelly Wilkinson | @EDGI-Comms|*enter text here*  | https://github.com/edgi-govdata-archiving/EEW_Planning/issues/assigned/EDGI-Comms |
+| Cole Alder | @calderEDJ |EEW website maintenance; event support; participant offboarding, visualization / outcome development and management; media coverage tracking  | https://github.com/edgi-govdata-archiving/EEW_Planning/issues/assigned/calderEDJ |
+| Casey Greenleaf | @crgreenleaf |EEW event support, participant onboarding, partnership and outreach co-coordinator, general questions   | https://github.com/edgi-govdata-archiving/EEW_Planning/issues/assigned/crgreenleaf |
+| Steve Hansen | @shansen5 | Programming and database support; Jupyter Notebook development; Mentoring on programming and development; Event notebook demonstrations| https://github.com/edgi-govdata-archiving/EEW_Planning/issues/assigned/shansen5 |
+| Chris Sellers | @csellers9 | Moderating Database/Notebook-writing group; Liaison to SBU faculty, also to EPA ECHO staff | https://github.com/edgi-govdata-archiving/EEW_Planning/issues/assigned/csellers9 |
+| Eric Nost | @ericnost  | Github use & management, general questions, code reviews for Jupyter notebooks, data visualization and research/contextualization tracks | https://github.com/edgi-govdata-archiving/EEW_Planning/issues/assigned/ericnost |
+| Kelsey Breseman | @Frijol | Github use & management, general questions, interfacing with EDGI, code reviews for Jupyter notebooks | https://github.com/edgi-govdata-archiving/EEW_Planning/issues/assigned/frijol
+| Sung-Gheel Jang | @sunggheel | ECHO database hosted at Stonybrook University | https://github.com/edgi-govdata-archiving/EEW_Planning/issues/assigned/sunggheel |
+| Paul St. Denis | @pstdenis | ECHO database hosted at Stonybrook University  | https://github.com/edgi-govdata-archiving/EEW_Planning/issues/assigned/pstdenis |
+| Dan Pascucci | @danpascucci |*enter text here*  | https://github.com/edgi-govdata-archiving/EEW_Planning/issues/assigned/danpascucci |
+| Dietmar Offenhuber | @dietoff |Data visualization track, UX research, EEW in the classroom| https://github.com/edgi-govdata-archiving/EEW_Planning/issues/assigned/dietoff |
+| Gaby Trudo| @gabrielletrudo | Communications and social media intern| https://github.com/edgi-govdata-archiving/EEW_Planning/issues/assigned/gabrielletrudo |
 
 ## How to use this repo
 We are using a Github Project attached to this repo to manage tasks associated with organizing the EEW events. You can find the Project board [here](https://github.com/edgi-govdata-archiving/EEW_Planning/projects/1) (or look for the Projects tab at the top of this repo.)


### PR DESCRIPTION
Just an idea – your personal link gets you directly to all the issues assigned to you in the repo. Do you want/like this in the readme?

┆Issue is synchronized with this [Trello card](https://trello.com/c/3QI2J7mZ)
